### PR TITLE
Added checks to GetContextGroupsAsync()

### DIFF
--- a/how-to.v1/interop-example/OpenFinIntegration.cs
+++ b/how-to.v1/interop-example/OpenFinIntegration.cs
@@ -72,7 +72,9 @@ namespace OpenFin.Interop.Win.Sample
                 InteropContextReceived?.Invoke(this, new ContextReceivedEventArgs(ctx));
             });
             var contextGroups = await _interopClient.GetContextGroupsAsync();
-            var contextGroupIds = contextGroups.Select(group => group.Id).ToArray();
+
+            // In the case of EB we may get back results for context groups that do not have any associated metadata such as color, etc. Ignore those.
+            var contextGroupIds = contextGroups.Where(group => group.DisplayMetadata.Color != null).Select(group => group.Id).ToArray();
             InteropContextGroupsReceived?.Invoke(this, new InteropContextGroupsReceivedEventArgs(contextGroupIds));
             InteropConnected?.Invoke(this, EventArgs.Empty);
         }

--- a/how-to.v2/interop-example/OpenFinIntegration.cs
+++ b/how-to.v2/interop-example/OpenFinIntegration.cs
@@ -114,10 +114,11 @@ namespace OpenFin.Interop.Win.Sample
                 Debug.WriteLine($"Interop Context Received! {ctx.Name}");
                 InteropContextReceived(this, new ContextReceivedEventArgs(ctx));
             });
-            _interopClient.GetContextGroupsAsync().ContinueWith(t =>
+            await _interopClient.GetContextGroupsAsync().ContinueWith(t =>
             {
                 var contextGroups = t.Result;
-                var contextGroupIds = contextGroups.Select(group => group.Id).ToArray();
+                // In the case of EB we may get back results for context groups that do not have any associated metadata such as color, etc. Ignore those.
+                var contextGroupIds = contextGroups.Where(group => group.DisplayMetadata.Color != null).Select(group => group.Id).ToArray();
                 InteropContextGroupsReceived(this, new InteropContextGroupsReceivedEventArgs(contextGroupIds));
             });
             


### PR DESCRIPTION
Ignore those contexts that do not contain any valid DisplayMetaData. This might be the case for contexts returned by EB.